### PR TITLE
Trim title text for any whitespace characters

### DIFF
--- a/src/fetchTitle.ts
+++ b/src/fetchTitle.ts
@@ -4,6 +4,6 @@ import * as cheerio from "cheerio";
 export async function fetchTitle(url: string): Promise<string> {
   const res = await axios.get<string>(url);
   const $ = cheerio.load(res.data);
-  const title = $("title").text();
+  const title = $("title").text().trim();
   return title;
 }


### PR DESCRIPTION
There are some cases where the title includes new lines, tabs, etc. Example below:

```html
<title>
		
	  
	  
	  
	  Actual title
	  
</title>
```

Would currently result in:

```md
[
		
	  
	  
	  
	  Actual title
	  
](https://example.com)
```

After proposed change results in:

```md
[Actual title](https://example.com)
```